### PR TITLE
Update home_assistant_glow.yaml

### DIFF
--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -12,7 +12,7 @@ esphome:
   comment: '${device_description}'
   project:
     name: "klaasnicolaas.home_assistant_glow"
-    version: "1.1.1"
+    version: "1.1.2"
   platform: ESP32
   board: nodemcu-32s
 

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -108,4 +108,5 @@ sensor:
       device_class: energy
       accuracy_decimals: 3
       filters:
+        # multiply value = 1 / imp value
         - multiply: 0.001

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -85,7 +85,9 @@ text_sensor:
 sensor:
   - platform: pulse_meter
     name: '${friendly_name} - Power consumption'
-    unit_of_measurement: 'Watt'
+    unit_of_measurement: 'W'
+    state_class: measurement
+    device_class: power
     icon: mdi:flash-outline
     accuracy_decimals: 0
     pin: ${pulse_pin}


### PR DESCRIPTION
- Use W rather than Watt to bring in line with [ha documentation](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes)

- add `state_class` and `device_class` to `pulse_meter` sensor so the power consumption can be used in Statistics Graph Card, as [here](https://www.home-assistant.io/more-info/statistics/), not just total usage.