### PR TITLE
Change the red light behaviour

### DIFF
--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -101,7 +101,9 @@ sensor:
       then:
         - light.turn_on:
             id: led_red
-            flash_length: 400ms
+        - delay: 0.5s
+        - light.turn_off:
+            id: led_red
     filters:
       # multiply value = (60 / imp value) * 1000
       # - multiply: 60


### PR DESCRIPTION
This solves the problem for the red LED that stays on all the time.

---
Note that this fix may not be a definitive solution to your problem! A red LED may remain ON because, it has measured several pulses in a short time and therefore the previous state of the LED can only be ON.