### PR TITLE
Remove underscores from device name

### DIFF
--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -5,7 +5,7 @@
 # meter, useful if you do not have a serial port (P1).
 #
 substitutions:
-  device_name: home_assistant_glow
+  device_name: home-assistant-glow
   friendly_name: House
   device_description: "Measure your energy consumption with the pulse LED on your smart meter"
   pulse_pin: GPIO12


### PR DESCRIPTION
Made this change because of this message in the ESPHome validation console:

`Using the '_' (underscore) character in the hostname is discouraged as it can cause problems with some DHCP and local name services.` See also [this information](https://esphome.io/guides/faq.html#why-shouldn-t-i-use-underscores-in-my-device-name).

### Breaking change

It's a breaking change because after updating your Glow, it will no longer come online in Home Assistant. I recommend manual download and upload the compiled file on the Glow's web server page.