### PR TITLE
Update home_assistant_glow.yaml

### DIFF
--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -113,8 +113,8 @@ sensor:
       name: '${friendly_name} - Total energy'
       unit_of_measurement: 'kWh'
       icon: mdi:circle-slice-3
-      last_reset_type: auto
-      state_class: measurement
+      #last_reset_type: auto
+      state_class: total_increasing
       device_class: energy
       accuracy_decimals: 3
       filters:

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -113,7 +113,6 @@ sensor:
       name: '${friendly_name} - Total energy'
       unit_of_measurement: 'kWh'
       icon: mdi:circle-slice-3
-      #last_reset_type: auto
       state_class: total_increasing
       device_class: energy
       accuracy_decimals: 3


### PR DESCRIPTION
fix the ESP Home 2021.9.0 error with deprecated last_reset_type and state_class (https://github.com/klaasnicolaas/home-assistant-glow/issues/51)

close #51 