### PR TITLE
Change master to main branch

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -4,7 +4,7 @@ name: Sync labels
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/labels.yml
   workflow_dispatch:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -4,7 +4,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Main will be the new default branch name from now on and we say goodbye to the master branch.