### PR TITLE
#88 Fix entity_category by removing extra tags

### DIFF
--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -92,16 +92,13 @@ text_sensor:
   - platform: version
     hide_timestamp: true
     name: "${friendly_name} - ESPHome Version"
-    entity_category: diagnostic 
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} - IP Address"
       icon: mdi:wifi
-      entity_category: diagnostic 
     ssid:
       name: "${friendly_name} - Connected SSID"
       icon: mdi:wifi-strength-2
-      entity_category: diagnostic 
 
 sensor:
   - platform: pulse_meter


### PR DESCRIPTION
Remove extra tags for entity_category to correctly reflect the sensors for SSID, IP and version as diagnostic sensors in HA