### PR TITLE
Add filters for reducing amount of data output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,10 @@ A number of users have reported receiving the recommended diode board from vario
 
 The large triangular part of the diode, should be soldered to the positive side of the board not the negative. If yours is orientated as above, you should desolder the photodiode invert it and resolder so the larger triangular part of the diode is connected to positive.
 
+### Reduce the amount of data the sensors produce
+
+Depending on the `pulse_rate` variable, the type of house/apartment and the heating system in use, the sensors that are exposed to Home Assistant may produce a lot of data. For example, with the default `pulse_rate` in the file, 1000, a power consumption of 3600 W means that the sensors produce 2 HA state changes per second (which means 7200 state changes per hour). If you don't need that kind of granularity, you can use [ESPHome sensor filters](https://esphome.io/components/sensor/index.html#sensor-filters) filters to reduce the rate of updates written to Home Assistant. With the commented-out filters in [home_assistant_glow.yaml][file] enabled, only 396 state changes will be produced per hour.
+
 ### My Daily Energy won't reset
 
 Issue: [#140][issue_140]

--- a/Readme.md
+++ b/Readme.md
@@ -119,7 +119,7 @@ The large triangular part of the diode, should be soldered to the positive side 
 
 ### Reduce the amount of data the sensors produce
 
-Depending on the `pulse_rate` variable, the type of house/apartment and the heating system in use, the sensors that are exposed to Home Assistant may produce a lot of data. For example, with the default `pulse_rate` in the file, 1000, a power consumption of 3600 W means that the sensors produce 2 HA state changes per second (which means 7200 state changes per hour). If you don't need that kind of granularity, you can use [ESPHome sensor filters](https://esphome.io/components/sensor/index.html#sensor-filters) filters to reduce the rate of updates written to Home Assistant. With the commented-out filters in [home_assistant_glow.yaml][file] enabled, only 396 state changes will be produced per hour.
+Depending on the configured `pulse rate`, the type of house/apartment and the heating system in use, the sensors that are exposed to Home Assistant may produce a lot of data. For example, with the default `pulse rate` 1000, a power consumption of 3600 W means that the sensors produce 2 HA state changes per second (which means 7200 state changes per hour). If you don't need that kind of granularity, you can use [ESPHome sensor filters](https://esphome.io/components/sensor/index.html#sensor-filters) to reduce the rate of updates written to Home Assistant. With the commented-out filters in the [home_assistant_glow.yaml][file] enabled, only 396 state changes will be produced per hour.
 
 ### My Daily Energy won't reset
 

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -177,7 +177,7 @@ sensor:
       - lambda: return x * ((60.0 / id(select_pulse_rate).state) * 1000.0);
 
       # Update the sensor with an average every 10th second. See
-      # https://github.com/klaasnicolaas/home-assistant-glowReadme.md#reduce-the-amount-of-data-the-sensors-produce
+      # https://github.com/klaasnicolaas/home-assistant-glow/#reduce-the-amount-of-data-the-sensors-produce
       # for more information.
       #
       #- throttle_average: 10s
@@ -196,8 +196,8 @@ sensor:
         # - multiply: 0.001
         - lambda: return x * (1.0 / id(select_pulse_rate).state);
 
-        # Update the sensor once per 0.1 kWh consumed, or every 5th minute,
-        # whichever happens sooner. See https://github.com/klaasnicolaas/home-assistant-glowReadme.md#reduce-the-amount-of-data-the-sensors-produce
+        # Update the sensor once per 0.1 kWh consumed, or every 5th minute, whichever happens sooner.
+        # See https://github.com/klaasnicolaas/home-assistant-glow/#reduce-the-amount-of-data-the-sensors-produce
         # for more information.
         #- delta: 0.01
         #- heartbeat: 300s

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -181,6 +181,7 @@ sensor:
       # for more information.
       #
       #- throttle_average: 10s
+      #- filter_out: NaN
 
     total:
       name: '${friendly_name} - Total Energy'

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -164,7 +164,7 @@ sensor:
     accuracy_decimals: 0
     pin: ${pulse_pin}
     # internal_filter: 100ms
-    on_value:
+    on_raw_value:
       then:
         - light.turn_on:
             id: led_red

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -198,7 +198,7 @@ sensor:
         # Update the sensor once per 0.1 kWh consumed, or every 5th minute,
         # whichever happens sooner. See https://github.com/klaasnicolaas/home-assistant-glowReadme.md#reduce-the-amount-of-data-the-sensors-produce
         # for more information.
-        #- delta: 0.1
+        #- delta: 0.01
         #- heartbeat: 300s
 
   # Total day usage

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -176,10 +176,10 @@ sensor:
       # - multiply: 60
       - lambda: return x * ((60.0 / id(select_pulse_rate).state) * 1000.0);
 
-      # Enable this if you want to limit the amount of data
-      # this sensor writes to the HA recorder database. Instead
-      # of writing a state change for each blink of the LED,
-      # the sensor will return an average every 10th second.
+      # Update the sensor with an average every 10th second. See
+      # https://github.com/klaasnicolaas/home-assistant-glowReadme.md#reduce-the-amount-of-data-the-sensors-produce
+      # for more information.
+      #
       #- throttle_average: 10s
 
     total:
@@ -195,12 +195,9 @@ sensor:
         # - multiply: 0.001
         - lambda: return x * (1.0 / id(select_pulse_rate).state);
 
-        # Enable these two filters if you want to limit the
-        # amount of data this sensor writes to the HA recorder
-        # database. Instead of writing a state change for each
-        # blink of the LED, the sensor will only be updated
-        # once per 0.1 kWh consumed, or every 5th minute,
-        # whichever happens sooner.
+        # Update the sensor once per 0.1 kWh consumed, or every 5th minute,
+        # whichever happens sooner. See https://github.com/klaasnicolaas/home-assistant-glowReadme.md#reduce-the-amount-of-data-the-sensors-produce
+        # for more information.
         #- delta: 0.1
         #- heartbeat: 300s
 

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -179,7 +179,6 @@ sensor:
       # Update the sensor with an average every 10th second. See
       # https://github.com/klaasnicolaas/home-assistant-glow/#reduce-the-amount-of-data-the-sensors-produce
       # for more information.
-      #
       #- throttle_average: 10s
       #- filter_out: NaN
 

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -1,7 +1,7 @@
 ---
 # Home Assistant Glow
 #
-# Read your electricity meter by means of the pulse LED on your 
+# Read your electricity meter by means of the pulse LED on your
 # meter, useful if you do not have a serial port (P1).
 # © Klaas Schoute
 #
@@ -168,13 +168,20 @@ sensor:
       then:
         - light.turn_on:
             id: led_red
-        - delay: 0.5s
+        - delay: 0.2s
         - light.turn_off:
             id: led_red
     filters:
       # multiply value = (60 / imp value) * 1000
       # - multiply: 60
       - lambda: return x * ((60.0 / id(select_pulse_rate).state) * 1000.0);
+
+      # Enable this if you want to limit the amount of data
+      # this sensor writes to the HA recorder database. Instead
+      # of writing a state change for each blink of the LED,
+      # the sensor will return an average every 10th second.
+      #- throttle_average: 10s
+
     total:
       name: '${friendly_name} - Total Energy'
       id: sensor_total_energy
@@ -187,7 +194,17 @@ sensor:
         # multiply value = 1 / imp value
         # - multiply: 0.001
         - lambda: return x * (1.0 / id(select_pulse_rate).state);
-  # Total day useage
+
+        # Enable these two filters if you want to limit the
+        # amount of data this sensor writes to the HA recorder
+        # database. Instead of writing a state change for each
+        # blink of the LED, the sensor will only be updated
+        # once per 0.1 kWh consumed, or every 5th minute,
+        # whichever happens sooner.
+        #- delta: 0.1
+        #- heartbeat: 300s
+
+  # Total day usage
   - platform: total_daily_energy
     name: '${friendly_name} - Daily Energy'
     id: sensor_total_daily_energy


### PR DESCRIPTION
This change adds commented-out samples of how to use filters to reduce the amount of data that are written to the HA recorder database by default.

Depending on the configured `pulse rate`, the type of house/apartment and the heating system in use, this may or may not be a problem in practice. For example, with the default `pulse rate` of `1000`, a power consumption of 3600 W means that the sensors produce 2 HA state changes per second (which means 7200 state changes per hour). With the commented-out filters enabled, only 396 state changes will be produced per hour.