### PR TITLE
Migrate to new board platform configuration

### DIFF
--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -27,7 +27,11 @@ esphome:
   project:
     name: "klaasnicolaas.home_assistant_glow"
     version: "3.0.0"
-  platform: ESP32
+
+# Choose the right Platform
+# esp32: https://esphome.io/components/esp32.html
+# esp8266: https://esphome.io/components/esp8266.html
+esp32:
   board: nodemcu-32s
 
 # WiFi credentials #


### PR DESCRIPTION
according to https://esphome.io/components/esphome.html the recommended core-configuration is now split into
esphome and esp32 (https://esphome.io/components/esp32.html) or esp8266 (https://esphome.io/components/esp8266.html)