### PR TITLE
Change default pulse pin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ How the photodiode is connected to the ESP board of your choice.
 | PHOTODIODE | ESP32        | Wemos D1 / ESP8266 |
 |------------|--------------|--------------------|
 | A0         | NOT USING    | NOT USING          |
-| DO         | D12 (GPIO12) | D6 (GPIO12)        |
+| DO         | D13 (GPIO13) | D7 (GPIO13)        |
 | VCC        | 3V3          | 3V3                |
 | GND        | GND          | GND                |
 

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -10,7 +10,9 @@ substitutions:
   friendly_name: House
   project_version: "3.1.0"
   device_description: "Measure your energy consumption with the pulse LED on your smart meter"
-  pulse_pin: GPIO12
+
+  # Define the GPIO pins
+  pulse_pin: GPIO13
   status_led: GPIO5
   led_pin_red: GPIO2
   led_pin_green: GPIO4

--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -12,6 +12,8 @@ substitutions:
   device_description: "Measure your energy consumption with the pulse LED on your smart meter"
   pulse_pin: GPIO12
   status_led: GPIO5
+  led_pin_red: GPIO2
+  led_pin_green: GPIO4
 
   # Webserver credentials ⬇ #
   web_username: 'glow'
@@ -87,10 +89,10 @@ output:
   #   pin: GPIO5
   #   id: output_blue
   - platform: gpio
-    pin: GPIO2
+    pin: ${led_pin_red}
     id: output_red
   - platform: gpio
-    pin: GPIO4
+    pin: ${led_pin_green}
     id: output_green
 
 light:


### PR DESCRIPTION
This pull request changes the default pulse pin to a different GPIO, so you no longer get a warning in the ESPHome console.

Fixes #164

_I also want to adjust the GPIO pins for the RGB LED in the future if they give a warning, I'm still looking for feedback/advice which should be the new ones._