### PR TITLE
Throttled update interval of power sensors

### DIFF
--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -174,6 +174,8 @@ sensor:
     filters:
       # multiply value = (60 / imp value) * 1000
       # - multiply: 60
+      - throttle_average: 10s
+      - filter_out: nan
       - lambda: return x * ((60.0 / id(select_pulse_rate).state) * 1000.0);
     total:
       name: '${friendly_name} - Total Energy'
@@ -186,6 +188,7 @@ sensor:
       filters:
         # multiply value = 1 / imp value
         # - multiply: 0.001
+        - heartbeat: 60s
         - lambda: return x * (1.0 / id(select_pulse_rate).state);
   # Total day useage
   - platform: total_daily_energy
@@ -198,6 +201,7 @@ sensor:
     device_class: energy
     accuracy_decimals: 3
     filters:
+      - heartbeat: 60s
       # Multiplication factor from W to kW is 0.001
       - multiply: 0.001
 


### PR DESCRIPTION
This PR does 2 things:

1. It throttles the update interval of the power pulse meter. On power meters with e.g. 10000 pulses/kWh you will get permanent sub second sensor updates that are pushed to home assistant and add a strain to the history recorder. In this solution the average pulse meter result of the last 10s ist calculated and sent to home assistant. If no update occurs nothing is send (filter_out: none).

2. It throttles the update of the daily and total consumption sensors to 60s. Here not via average but via heartbeat filter (last sensor value is sent). That interval should be more then enough for a total consumption sensor.