### PR TITLE
Wrong values after upgrade to ESPHome 2023.8.0

### DIFF
--- a/home_assistant_glow.yaml
+++ b/home_assistant_glow.yaml
@@ -168,6 +168,7 @@ sensor:
   # Pulse meter
   - platform: pulse_meter
     name: '${friendly_name} - Power Consumption'
+    internal_filter_mode: PULSE
     id: sensor_energy_pulse_meter
     unit_of_measurement: 'W'
     state_class: measurement


### PR DESCRIPTION
When upgrading from 2023.7.1 to 8.0, it appears that the `pulse_meter` function has become broken or changed. The counter goes crazy and increments at a high rate endlessly.

There was a lot of issues:
#298 #301 #302 #309

 In ESPHome 2023.8.0, there was a `pulse_meter` refactoring. The default mode is now EDGE instead of PULSE as before.

To use the PULSE mode, you need to add the `internal_filter_mode` option to the `pulse_meter` configuration, like this:

```
  - platform: pulse_meter
    name: '${friendly_name} - Power Consumption'
    id: sensor_energy_pulse_meter
    internal_filter_mode: PULSE
    unit_of_measurement: 'W'
    state_class: measurement
    ...
```