### PR TITLE
Update board configuration for ESP32 and ESP8266

### DIFF
--- a/home-assistant-glow/esp32.yaml
+++ b/home-assistant-glow/esp32.yaml
@@ -9,7 +9,7 @@ substitutions:
   device_name: home-assistant-glow
   friendly_name: Home Assistant Glow
   project_version: "4.0.0"
-  device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP32"
+  device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP32 Generic"
 
   # Define the GPIO pins
   pulse_pin: GPIO26
@@ -29,7 +29,9 @@ dashboard_import:
   package_import_url: github://klaasnicolaas/home-assistant-glow/home-assistant-glow/esp32.yaml@main
 
 esp32:
-  board: nodemcu-32s
+  board: esp32dev
+  framework:
+    type: arduino
 
 packages:
   basis: !include ../components/basis.yaml

--- a/home-assistant-glow/esp8266.yaml
+++ b/home-assistant-glow/esp8266.yaml
@@ -9,7 +9,7 @@ substitutions:
   device_name: home-assistant-glow
   friendly_name: Home Assistant Glow
   project_version: "4.0.0"
-  device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP8266"
+  device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP8266 Generic"
 
   # Define the GPIO pins
   pulse_pin: GPIO13
@@ -29,7 +29,7 @@ dashboard_import:
   package_import_url: github://klaasnicolaas/home-assistant-glow/home-assistant-glow/esp32.yaml@main
 
 esp8266:
-  board: nodemcuv2
+  board: esp01_1m
 
 packages:
   basis: !include ../components/basis.yaml


### PR DESCRIPTION
Due to the variety of boards on the market, it may be better to use a more general board type in the YAML configuration files.