### PR TITLE
Include full YAML config after dashboard import

### DIFF
--- a/home-assistant-glow/d1_mini.yaml
+++ b/home-assistant-glow/d1_mini.yaml
@@ -27,6 +27,7 @@ esphome:
 
 dashboard_import:
   package_import_url: github://klaasnicolaas/home-assistant-glow/home-assistant-glow/d1_mini.yaml@main
+  import_full_config: true
 
 esp8266:
   board: d1_mini

--- a/home-assistant-glow/esp32.yaml
+++ b/home-assistant-glow/esp32.yaml
@@ -27,6 +27,7 @@ esphome:
 
 dashboard_import:
   package_import_url: github://klaasnicolaas/home-assistant-glow/home-assistant-glow/esp32.yaml@main
+  import_full_config: true
 
 esp32:
   board: esp32dev

--- a/home-assistant-glow/esp8266.yaml
+++ b/home-assistant-glow/esp8266.yaml
@@ -27,6 +27,7 @@ esphome:
 
 dashboard_import:
   package_import_url: github://klaasnicolaas/home-assistant-glow/home-assistant-glow/esp8266.yaml@main
+  import_full_config: true
 
 esp8266:
   board: esp01_1m


### PR DESCRIPTION
This will make it easier for everyone to make adjustments to the YAML config because the entire config will be imported into your ESPHome dashboard after adoption.