### PR TITLE
Deploy only on published releases

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -6,9 +6,9 @@ on:
   push:
     branches:
       - main
-  # release:
-  #   types:
-  #     - published
+  release:
+    types:
+      - published
   workflow_dispatch:
   pull_request:
     branches-ignore:
@@ -144,7 +144,7 @@ jobs:
 
   build-docs:
     name: Build documentation
-    if: contains(fromJSON('["workflow_dispatch", "push", "schedule"]'), github.event_name) && github.ref == 'refs/heads/main'
+    if: contains(fromJSON('["workflow_dispatch", "release"]'), github.event_name) && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: combined-manifests
     steps:


### PR DESCRIPTION
- CI build tests will run on `push`, `release`, `pull_request`, `workflow_dispatch` and `schedule`.
- Deploying the new firmware will only work on `workflow_dispatch` or `release`.

We do not use versioned documentation so please note that there may sometimes be a discrepancy between code and docs 😉 