### PR TITLE
Add ota ids to allow local overriding

### DIFF
--- a/components/updates.yaml
+++ b/components/updates.yaml
@@ -1,7 +1,9 @@
 # OTA configuration #
 ota:
   - platform: esphome
+    id: ota_esphome
   - platform: http_request
+    id: ota_http_request
 
 update:
   - platform: http_request


### PR DESCRIPTION
Without any id in packaged ota entries, people cannot add ota passwords in local adopted configurations. 