### PR TITLE
Refactor the build & deploy github actions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 ---
 name-template: "v$RESOLVED_VERSION"
-tag-template: "v$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
 
@@ -58,6 +58,8 @@ version-resolver:
 template: |
   ## What's changed
 
+  _To receive a notification on new releases, click on **Watch** > **Custom** > **Releases** on the top._
+
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -93,8 +93,9 @@ jobs:
       - name: Determine ref
         id: determine_ref
         run: |
-          if [[ "${{ github.ref_name }}" != "main" ]]; then
-            sed -i "s/ref: .*/ref: ${{ github.ref_name }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            branch_name=$(echo "${{ github.ref }}" | sed 's|refs/heads/||')
+            sed -i "s/ref: .*/ref: $branch_name/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
           else
             echo "Skipping sed command because the branch is main."
           fi

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -104,7 +104,7 @@ jobs:
           else
             echo "Skipping sed command because the branch is main."
           fi
-      - name: Log Changed YAML file
+      - name: 🧪 Display changed YAML file
         run: cat ${{ matrix.firmware }}/${{ matrix.device }}.yaml
       - name: 🔨 Build firmware
         uses: esphome/build-action@v3.1.0

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -13,10 +13,6 @@ on:
       release-url:
         required: false
         type: string
-    outputs:
-      run-id:
-        description: "The ID of the workflow run"
-        value: ${{ github.run_id }}
   pull_request:
     branches-ignore:
       - renovate/docusaurus**

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -100,7 +100,7 @@ jobs:
         id: determine_ref
         run: |
           if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            sed -i "s/ref: .*/ref: ${{ github.head_ref }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
+            sed -i "s/ref: .*/ref: ${{ github.head_ref || github.ref }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
           else
             echo "Skipping sed command because the branch is main."
           fi

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -92,14 +92,10 @@ jobs:
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v4.1.7
-      - name: Determine ref
-        id: determine_ref
+      - name: 🔍 Determine ref - ESPHome packages
+        if: ${{ !contains(fromJSON('["workflow_dispatch", "release", "workflow_call"]'), github.event_name) }}
         run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            sed -i "s/ref: .*/ref: ${{ github.head_ref || 'klaas-2024-035' }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
-          else
-            echo "Skipping sed command because the branch is main."
-          fi
+          sed -i "s/ref: .*/ref: ${{ github.head_ref || 'klaas-2024-035' }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
       - name: 🧪 Display changed YAML file
         run: cat ${{ matrix.firmware }}/${{ matrix.device }}.yaml
       - name: 🔨 Build firmware

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -94,7 +94,7 @@ jobs:
         id: determine_ref
         run: |
           if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            branch_name=$(echo "${{ github.ref }}" | sed 's|refs/heads/||')
+            branch_name=$(echo "${{ github.ref }}" | sed 's@refs/heads/@@')
             sed -i "s/ref: .*/ref: $branch_name/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
           else
             echo "Skipping sed command because the branch is main."

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -100,7 +100,7 @@ jobs:
         id: determine_ref
         run: |
           if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            sed -i "s/ref: .*/ref: ${{ github.head_ref || github.ref }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
+            sed -i "s/ref: .*/ref: ${{ github.head_ref || 'klaas-2024-035' }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
           else
             echo "Skipping sed command because the branch is main."
           fi

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -94,7 +94,7 @@ jobs:
         id: determine_ref
         run: |
           if [[ "${{ github.ref_name }}" != "main" ]]; then
-            sed -i "s/ref: .*/ref: {{ github.ref_name }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
+            sed -i "s/ref: .*/ref: ${{ github.ref_name }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
           else
             echo "Skipping sed command because the branch is main."
           fi

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - develop
-      - release/**
+      - main
   release:
     types:
       - published
@@ -90,6 +90,16 @@ jobs:
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v4.1.7
+      - name: Determine ref
+        id: determine_ref
+        run: |
+          if [[ "${{ github.ref_name }}" != "main" ]]; then
+            sed -i "s/ref: .*/ref: {{ github.ref_name }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
+          else
+            echo "Skipping sed command because the branch is main."
+          fi
+      - name: Log Changed YAML file
+        run: cat ${{ matrix.firmware }}/${{ matrix.device }}.yaml
       - name: 🔨 Build firmware
         uses: esphome/build-action@v3.1.0
         id: esphome-build

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -1,16 +1,22 @@
 ---
-# Build the ESPHome firmwares for the Home Assistant Glow project.
-name: Build & Deploy firmware
+# Test building ESPHome firmwares for the Home Assistant Glow project.
+name: Build firmware
 
 on:
   push:
     branches:
       - develop
-      - main
-  release:
-    types:
-      - published
+      - release/**
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      release-url:
+        required: false
+        type: string
+    outputs:
+      run-id:
+        description: "The ID of the workflow run"
+        value: ${{ github.run_id }}
   pull_request:
     branches-ignore:
       - renovate/docusaurus**
@@ -106,7 +112,7 @@ jobs:
         with:
           yaml_file: ${{ matrix.firmware }}/${{ matrix.device }}.yaml
           version: ${{ matrix.version || 'latest' }}
-          release_url: ${{ github.event.release.html_url || env.RELEASE_URL }}
+          release_url: ${{ inputs.release-url || env.RELEASE_URL }}
           cache: true
       - name: 🚚 Move generated files to output
         run: |
@@ -122,83 +128,3 @@ jobs:
           name: build-${{ matrix.firmware}}-${{ matrix.device }}
           path: output
           retention-days: 1
-
-  combined-manifests:
-    name: Combine ${{ matrix.project }} manifests
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - project: home-assistant-glow
-            name: Home Assistant Glow
-    steps:
-      - name: ⤵️ Download specific artifacts
-        uses: actions/download-artifact@v4.1.7
-        with:
-          pattern: build-${{ matrix.project }}-*
-          merge-multiple: true
-          path: files
-      - name: 🔨 Generate device manifest.json
-        run: |
-          version=$(cat files/*/version | sort -V | tail -n 1)
-          jq -s --arg version "$version" '{"name": "${{ matrix.name }}", "version": $version, "home_assistant_domain": "esphome", "builds":.}' files/*/manifest.json > files/manifest.json
-      - name: 🧪 Display structure of job
-        run: ls -R
-      - name: ⬆️ Upload project artifact
-        uses: actions/upload-artifact@v4.3.3
-        with:
-          name: ${{ matrix.project }}
-          path: files
-          retention-days: 1
-
-  build-docs:
-    name: Build documentation
-    if: contains(fromJSON('["workflow_dispatch", "release"]'), github.event_name) && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: combined-manifests
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v4.1.7
-      - name: ⬇️ Download all artifacts
-        uses: actions/download-artifact@v4.1.7
-        with:
-          pattern: "!build-*"
-          path: output
-      - name: 🗂️ Move firmware folders to static
-        run: mv output/* docs/static
-      - name: 🧪 Display structure of job
-        run: ls -R
-
-      - name: 🏗️ Set up Node.js
-        uses: actions/setup-node@v4.0.2
-        with:
-          node-version: 20.x
-      - name: 🏗️ Install Docusaurus dependencies
-        run: npm install --frozen-lockfile --non-interactive
-        working-directory: docs
-      - name: 🚀 Build Docusaurus
-        run: npm run build
-        working-directory: docs
-      - name: ⬆️ Upload pages artifacts
-        uses: actions/upload-pages-artifact@v3.0.1
-        with:
-          path: docs/build
-
-  deploy:
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: build-docs
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: 🏗️ Setup Github Pages
-        uses: actions/configure-pages@v5.0.0
-      - name: 🚀 Deploy to Github Pages
-        uses: actions/deploy-pages@v4.0.5
-        id: deployment

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -11,7 +11,7 @@ on:
   workflow_call:
     inputs:
       release-url:
-        required: false
+        required: true
         type: string
   pull_request:
     branches-ignore:
@@ -93,9 +93,9 @@ jobs:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v4.1.7
       - name: 🔍 Determine ref - ESPHome packages
-        if: ${{ !contains(fromJSON('["workflow_dispatch", "release", "workflow_call"]'), github.event_name) }}
+        if: ${{ !contains(fromJSON('["release", "workflow_call"]'), github.event_name) }}
         run: |
-          sed -i "s/ref: .*/ref: ${{ github.head_ref || 'klaas-2024-035' }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
+          sed -i "s/ref: .*/ref: ${{ github.head_ref }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
       - name: 🧪 Display changed YAML file
         run: cat ${{ matrix.firmware }}/${{ matrix.device }}.yaml
       - name: 🔨 Build firmware

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -94,8 +94,7 @@ jobs:
         id: determine_ref
         run: |
           if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            branch_name=$(echo "${{ github.ref }}" | sed 's@refs/heads/@@')
-            sed -i "s/ref: .*/ref: $branch_name/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
+            sed -i "s/ref: .*/ref: ${{ github.head_ref }}/g" ${{ matrix.firmware }}/${{ matrix.device }}.yaml
           else
             echo "Skipping sed command because the branch is main."
           fi

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   build-firmware:
     uses: klaasnicolaas/home-assistant-glow/.github/workflows/build-firmware.yaml@klaas-2024-035
+    name: Build firmware
     with:
       release-url: ${{ github.event.release.html_url }}
 

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -13,13 +13,10 @@ on:
 
 jobs:
   build-firmware:
-    name: Build firmware
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🔨 Build firmware
-        uses: ./.github/workflows/build-firmware.yaml@klaas-2024-035
-        with:
-          release-url: ${{ github.event.release.html_url }}
+    name: 🔨 Build firmware
+    uses: klaasnicolaas/home-assistant-glow/.github/workflows/build-firmware.yaml@klaas-2024-035
+    with:
+      release-url: ${{ github.event.release.html_url }}
 
   combined-manifests:
     name: Combine ${{ matrix.project }} manifests

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   build-firmware:
-    name: 🔨 Build firmware
     uses: klaasnicolaas/home-assistant-glow/.github/workflows/build-firmware.yaml@klaas-2024-035
     with:
       release-url: ${{ github.event.release.html_url }}

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -3,20 +3,26 @@
 name: Deploy firmware
 
 on:
-  push:
-    branches:
-      - klaas-2024-035
   release:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "The tag of the release to use in deployment"
+        required: true
+        type: string
+      release-url:
+        description: "The URL of the release to use in deployment"
+        required: true
+        type: string
 
 jobs:
   build-firmware:
-    uses: klaasnicolaas/home-assistant-glow/.github/workflows/build-firmware.yaml@klaas-2024-035
+    uses: klaasnicolaas/home-assistant-glow/.github/workflows/build-firmware.yaml@main
     name: Firmware
     with:
-      release-url: ${{ github.event.release.html_url }}
+      release-url: ${{ github.event.release.html_url || inputs.release-url }}
 
   combined-manifests:
     name: Combine ${{ matrix.project }} manifests
@@ -37,7 +43,7 @@ jobs:
           path: files
       - name: 🔨 Generate device manifest.json
         run: |
-          version=${{ github.event.release.tag_name || '4.1.0' }}
+          version=${{ github.event.release.tag_name || inputs.release-tag }}
           jq -s --arg version "$version" '{"name": "${{ matrix.name }}", "version": $version, "home_assistant_domain": "esphome", "builds":.}' files/*/manifest.json > files/manifest.json
       - name: 🧪 Display structure of job
         run: ls -R
@@ -81,19 +87,19 @@ jobs:
         with:
           path: docs/build
 
-  # deploy:
-  #   name: Deploy to GitHub Pages
-  #   runs-on: ubuntu-latest
-  #   needs: build-docs
-  #   permissions:
-  #     pages: write
-  #     id-token: write
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   steps:
-  #     - name: 🏗️ Setup Github Pages
-  #       uses: actions/configure-pages@v5.0.0
-  #     - name: 🚀 Deploy to Github Pages
-  #       uses: actions/deploy-pages@v4.0.5
-  #       id: deployment
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build-docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: 🏗️ Setup Github Pages
+        uses: actions/configure-pages@v5.0.0
+      - name: 🚀 Deploy to Github Pages
+        uses: actions/deploy-pages@v4.0.5
+        id: deployment

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -35,7 +35,6 @@ jobs:
           pattern: build-${{ matrix.project }}-*
           merge-multiple: true
           path: files
-          # run-id: ${{ needs.build-firmware.outputs.run-id }}
       - name: 🔨 Generate device manifest.json
         run: |
           version=${{ github.event.release.tag_name || '4.1.0' }}

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-firmware:
     uses: klaasnicolaas/home-assistant-glow/.github/workflows/build-firmware.yaml@klaas-2024-035
-    name: Build firmware
+    name: Firmware
     with:
       release-url: ${{ github.event.release.html_url }}
 
@@ -35,7 +35,7 @@ jobs:
           pattern: build-${{ matrix.project }}-*
           merge-multiple: true
           path: files
-          run-id: ${{ needs.build-firmware.outputs.run-id }}
+          # run-id: ${{ needs.build-firmware.outputs.run-id }}
       - name: 🔨 Generate device manifest.json
         run: |
           version=${{ github.event.release.tag_name || '4.1.0' }}

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -37,7 +37,7 @@ jobs:
           run-id: ${{ needs.build-firmware.outputs.run-id }}
       - name: 🔨 Generate device manifest.json
         run: |
-          version=$(cat files/*/version | sort -V | tail -n 1)
+          version=${{ github.event.release.tag_name || '4.1.0' }}
           jq -s --arg version "$version" '{"name": "${{ matrix.name }}", "version": $version, "home_assistant_domain": "esphome", "builds":.}' files/*/manifest.json > files/manifest.json
       - name: 🧪 Display structure of job
         run: ls -R

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -50,7 +50,7 @@ jobs:
 
   build-docs:
     name: Build documentation
-    # if: contains(fromJSON('["workflow_dispatch", "release"]'), github.event_name) && github.ref == 'refs/heads/main'
+    if: contains(fromJSON('["workflow_dispatch", "release"]'), github.event_name) && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: combined-manifests
     steps:

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -3,6 +3,9 @@
 name: Deploy firmware
 
 on:
+  push:
+    branches:
+      - klaas-2024-035
   release:
     types:
       - published
@@ -14,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🔨 Build firmware
-        uses: ./.github/workflows/build-firmware.yaml
+        uses: ./.github/workflows/build-firmware.yaml@klaas-2024-035
         with:
           release-url: ${{ github.event.release.html_url }}
 

--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -1,0 +1,100 @@
+---
+# Build & Deploy the ESPHome firmwares for the Home Assistant Glow project.
+name: Deploy firmware
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  build-firmware:
+    name: Build firmware
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔨 Build firmware
+        uses: ./.github/workflows/build-firmware.yaml
+        with:
+          release-url: ${{ github.event.release.html_url }}
+
+  combined-manifests:
+    name: Combine ${{ matrix.project }} manifests
+    runs-on: ubuntu-latest
+    needs: build-firmware
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: home-assistant-glow
+            name: Home Assistant Glow
+    steps:
+      - name: ⤵️ Download specific artifacts
+        uses: actions/download-artifact@v4.1.7
+        with:
+          pattern: build-${{ matrix.project }}-*
+          merge-multiple: true
+          path: files
+          run-id: ${{ needs.build-firmware.outputs.run-id }}
+      - name: 🔨 Generate device manifest.json
+        run: |
+          version=$(cat files/*/version | sort -V | tail -n 1)
+          jq -s --arg version "$version" '{"name": "${{ matrix.name }}", "version": $version, "home_assistant_domain": "esphome", "builds":.}' files/*/manifest.json > files/manifest.json
+      - name: 🧪 Display structure of job
+        run: ls -R
+      - name: ⬆️ Upload project artifact
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: ${{ matrix.project }}
+          path: files
+          retention-days: 1
+
+  build-docs:
+    name: Build documentation
+    # if: contains(fromJSON('["workflow_dispatch", "release"]'), github.event_name) && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: combined-manifests
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4.1.7
+      - name: ⬇️ Download all artifacts
+        uses: actions/download-artifact@v4.1.7
+        with:
+          pattern: "!build-*"
+          path: output
+      - name: 🗂️ Move firmware folders to static
+        run: mv output/* docs/static
+      - name: 🧪 Display structure of job
+        run: ls -R
+
+      - name: 🏗️ Set up Node.js
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20.x
+      - name: 🏗️ Install Docusaurus dependencies
+        run: npm install --frozen-lockfile --non-interactive
+        working-directory: docs
+      - name: 🚀 Build Docusaurus
+        run: npm run build
+        working-directory: docs
+      - name: ⬆️ Upload pages artifacts
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: docs/build
+
+  # deploy:
+  #   name: Deploy to GitHub Pages
+  #   runs-on: ubuntu-latest
+  #   needs: build-docs
+  #   permissions:
+  #     pages: write
+  #     id-token: write
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   steps:
+  #     - name: 🏗️ Setup Github Pages
+  #       uses: actions/configure-pages@v5.0.0
+  #     - name: 🚀 Deploy to Github Pages
+  #       uses: actions/deploy-pages@v4.0.5
+  #       id: deployment


### PR DESCRIPTION
This PR will refactor and improve the github workflows on testing & deployment 🔥 

- A seperate github action that only builds firmware, Which is useful during development
- A simplified deployment that can reuse the firmware build workflow (with `workflow_call` and inputs)
- Correct handling when using workflow_dispatch for both workflows
- Replacing the `ref` from ESPHome external packages, so that the test firmware build uses the dev/PR files
- `Workflow_dispatch` with specific inputs to keep the workflow running smoothly
- In the future release tags will be without `v`