### PR TITLE
Remove unnecessary if condition in deploy workflow

### DIFF
--- a/.github/workflows/deploy-firmware.yaml
+++ b/.github/workflows/deploy-firmware.yaml
@@ -21,7 +21,6 @@ on:
 
 jobs:
   build-firmware:
-    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: klaasnicolaas/home-assistant-glow/.github/workflows/build-firmware.yaml@main
     name: Firmware
     with:


### PR DESCRIPTION
During the first release in a new form, this immediately resulted in the CI being skipped. the if statement is actually not necessary and has therefore been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the deployment workflow by removing a conditional check, ensuring that the `build-firmware` job runs regardless of the branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->