### PR TITLE
Persistent values after reboot for sensor_total_energy and sensor_total_daily_energy

### DIFF
--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -61,10 +61,12 @@ sensor:
         - delay: 0.2s
         - light.turn_off:
             id: led_red
-    filters:
-      # multiply value = (60 / imp value) * 1000
-      # - multiply: 60
-      - lambda: return x * ((60.0 / id(select_pulse_rate).state) * 1000.0);
+      filters:
+        # multiply value = 1 / imp value
+        # - multiply: 0.001
+        - lambda: id(persist_sensor_total_energy) = id(sensor_total_energy).raw_state;
+            return x * (1.0 / id(select_pulse_rate).state);
+
 
     total:
       id: sensor_total_energy

--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -91,6 +91,7 @@ sensor:
     state_class: total_increasing
     device_class: energy
     accuracy_decimals: 3
+    restore: True
     filters:
       # Multiplication factor from W to kW is 0.001
       - multiply: 0.001

--- a/home-assistant-glow/esp32.yaml
+++ b/home-assistant-glow/esp32.yaml
@@ -61,3 +61,8 @@ captive_portal:
 
 # To have a "next url" for improv serial
 web_server:
+
+globals:
+  id: persist_sensor_total_energy
+  type: float
+  restore_value: True

--- a/home-assistant-glow/esp32.yaml
+++ b/home-assistant-glow/esp32.yaml
@@ -62,6 +62,9 @@ captive_portal:
 # To have a "next url" for improv serial
 web_server:
 
+preferences:
+  flash_write_interval: 5min
+
 globals:
   id: persist_sensor_total_energy
   type: float

--- a/home-assistant-glow/esp32.yaml
+++ b/home-assistant-glow/esp32.yaml
@@ -25,6 +25,11 @@ esphome:
   project:
     name: "klaasnicolaas.home-assistant-glow"
     version: "${project_version}"
+  on_boot: 
+  then:
+    - pulse_meter.set_total_pulses: 
+        id: sensor_energy_pulse_meter
+        value: !lambda "return id(persist_sensor_total_energy);"
 
 dashboard_import:
   package_import_url: github://klaasnicolaas/home-assistant-glow/home-assistant-glow/esp32.yaml@main


### PR DESCRIPTION
Changes to `pulse_meter`, `sensor_total_energy`, and `sensor_total_daily_energy` to restore their previous values after a reboot

Also adds `on_boot` flag to `esphome` which calls `pulse_meter.set_total_pulses` to manually restore the value as `pulse_meter` `total` doesn't have a `restore` flag. 

Finally, added `preferences` to restrict flash writes to once every 5 minutes, to reduce wear on flash memory.

Tested on ESP32 nodemcu-32s only.