### PR TITLE
Fix firmware path in manifest

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -116,7 +116,7 @@ jobs:
           echo ${{ steps.esphome-build.outputs.project-version }} > output/${{ matrix.device }}/project_version
       - name: 🔨 Alter path in manifest.json
         run: |
-          sed -i 's/^[^.]*\./\/${{ matrix.firmware }}\/${{ matrix.device }}\/${{ steps.esphome-build.outputs.name }}./' output/${{ matrix.device }}/manifest.json
+          sed -i 's/${{ steps.esphome-build.outputs.name }}\(\.[a-z]*\)\.bin/\/${{ matrix.firmware }}\/${{ matrix.device }}\/${{ steps.esphome-build.outputs.name }}\1.bin/' output/${{ matrix.device }}/manifest.json
           cat output/${{ matrix.device }}/manifest.json
       - name: ⬆️ Upload firmware / device artifact
         uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -115,7 +115,8 @@ jobs:
           echo ${{ steps.esphome-build.outputs.project-version }} > output/${{ matrix.device }}/project_version
       - name: 🔨 Alter path in manifest.json
         run: |
-          sed -i 's/${{ steps.esphome-build.outputs.name }}\//\/${{ matrix.firmware }}\/${{ matrix.device }}\//g' output/${{ matrix.device }}/manifest.json
+          sed -i 's#${{ steps.esphome-build.outputs.name }}#/${{ matrix.firmware }}/${{ matrix.device }}/&/#g' output/${{ matrix.device }}/manifest.json
+          cat output/${{ matrix.device }}/manifest.json
       - name: ⬆️ Upload firmware / device artifact
         uses: actions/upload-artifact@v4.4.0
         with:

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -105,6 +105,7 @@ jobs:
         with:
           yaml-file: ${{ matrix.firmware }}/${{ matrix.device }}.yaml
           version: ${{ matrix.version || 'latest' }}
+          release-summary: "Check the release notes for more information."
           release-url: ${{ inputs.release-url || env.RELEASE_URL }}
           cache: true
       - name: 🚚 Move generated files to output

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -116,7 +116,7 @@ jobs:
           echo ${{ steps.esphome-build.outputs.project-version }} > output/${{ matrix.device }}/project_version
       - name: 🔨 Alter path in manifest.json
         run: |
-          sed -i 's#${{ steps.esphome-build.outputs.name }}#/${{ matrix.firmware }}/${{ matrix.device }}&/#g' output/${{ matrix.device }}/manifest.json
+          sed -i 's/^[^.]*\./\/${{ matrix.firmware }}\/${{ matrix.device }}\/${{ steps.esphome-build.outputs.name }}./' output/${{ matrix.device }}/manifest.json
           cat output/${{ matrix.device }}/manifest.json
       - name: ⬆️ Upload firmware / device artifact
         uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -116,7 +116,7 @@ jobs:
           echo ${{ steps.esphome-build.outputs.project-version }} > output/${{ matrix.device }}/project_version
       - name: 🔨 Alter path in manifest.json
         run: |
-          sed -i 's#${{ steps.esphome-build.outputs.name }}#/${{ matrix.firmware }}/${{ matrix.device }}/&/#g' output/${{ matrix.device }}/manifest.json
+          sed -i 's#${{ steps.esphome-build.outputs.name }}#/${{ matrix.firmware }}/${{ matrix.device }}&/#g' output/${{ matrix.device }}/manifest.json
           cat output/${{ matrix.device }}/manifest.json
       - name: ⬆️ Upload firmware / device artifact
         uses: actions/upload-artifact@v4.4.0


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a `release-summary` parameter in the firmware build workflow to enhance user awareness of release notes.
	- Added a command to output the contents of `manifest.json` post-modification for improved debugging and verification.

- **Improvements**
	- Updated the file manipulation command to use a hash delimiter for better handling of paths in `manifest.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->