### PR TITLE
Set max_value for pulse_rate to 100000

### DIFF
--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -16,7 +16,7 @@ number:
     optimistic: true
     mode: box
     min_value: 100
-    max_value: 10000
+    max_value: 100000
     step: 100
     restore_value: yes
     initial_value: 1000


### PR DESCRIPTION
In my case, i need the pulse/kwh setting to be 100000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased maximum pulse rate setting from 10,000 to 100,000, allowing for a wider range of pulse rates.
- **Improvements**
	- Clarified comments in sensor configurations for better understanding.
	- Minor formatting adjustment for consistency in the total daily energy sensor configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->