### PR TITLE
Remove redundant friendly name occurances

### DIFF
--- a/components/basis.yaml
+++ b/components/basis.yaml
@@ -18,14 +18,14 @@ text_sensor:
   # ESPHome version
   - platform: version
     hide_timestamp: true
-    name: '${friendly_name} - ESPHome Version'
+    name: 'ESPHome Version'
   # IP address and connected SSID
   - platform: wifi_info
     ip_address:
-      name: '${friendly_name} - IP Address'
+      name: 'IP Address'
       icon: mdi:wifi
     ssid:
-      name: '${friendly_name} - Connected SSID'
+      name: 'Connected SSID'
       icon: mdi:wifi-strength-2
 
 sensor:

--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -47,7 +47,7 @@ sensor:
   # Pulse meter
   - platform: pulse_meter
     id: sensor_energy_pulse_meter
-    name: '${friendly_name} - Power Consumption'
+    name: 'Power Consumption'
     unit_of_measurement: W
     state_class: measurement
     device_class: power
@@ -68,7 +68,7 @@ sensor:
 
     total:
       id: sensor_total_energy
-      name: '${friendly_name} - Total Energy'
+      name: 'Total Energy'
       unit_of_measurement: kWh
       icon: mdi:circle-slice-3
       state_class: total_increasing
@@ -82,7 +82,7 @@ sensor:
   # Total day usage
   - platform: total_daily_energy
     id: sensor_total_daily_energy
-    name: '${friendly_name} - Daily Energy'
+    name: 'Daily Energy'
     power_id: sensor_energy_pulse_meter
     unit_of_measurement: kWh
     icon: mdi:circle-slice-3

--- a/home-assistant-glow/esp32.yaml
+++ b/home-assistant-glow/esp32.yaml
@@ -52,8 +52,7 @@ improv_serial:
 
 wifi:
   # Set up a wifi access point
-  ap:
-    ssid: '${friendly_name}'
+  ap: {}
 
 # In combination with the `ap` this allows the user
 # to provision wifi credentials to the device via WiFi AP.

--- a/home-assistant-glow/esp8266.yaml
+++ b/home-assistant-glow/esp8266.yaml
@@ -50,8 +50,7 @@ improv_serial:
 
 wifi:
   # Set up a wifi access point
-  ap:
-    ssid: '${friendly_name}'
+  ap: {}
 
 # In combination with the `ap` this allows the user
 # to provision wifi credentials to the device via WiFi AP.


### PR DESCRIPTION
Since [2023.2](https://esphome.io/changelog/2023.2.0.html) ESPHome now prepends the `friendly_name` specified in `esphome:` to the name of any sensors or components. This has resulted in the names of the sensors being doubled up as in `Electricty Meter Electricty Meter - WiFi Signal`.

This pull request removed the redundant friendly names to solve this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified naming for various sensors, enhancing clarity in the user interface.
	- Updated Wi-Fi access point configurations for ESP32 and ESP8266 devices, streamlining setup.

- **Bug Fixes**
	- Resolved inconsistencies in sensor naming that could lead to confusion.

- **Documentation**
	- Improved comments in configuration files for better understanding of settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->