### PR TITLE
Move pulse meter flash trigger to total sensor

### DIFF
--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -54,13 +54,6 @@ sensor:
     icon: mdi:flash-outline
     accuracy_decimals: 0
     pin: ${pulse_pin}
-    on_raw_value:
-      then:
-        - light.turn_on:
-            id: led_red
-        - delay: 0.2s
-        - light.turn_off:
-            id: led_red
     filters:
       # multiply value = (60 / imp value) * 1000
       # - multiply: 60
@@ -78,6 +71,11 @@ sensor:
         # multiply value = 1 / imp value
         # - multiply: 0.001
         - lambda: return x * (1.0 / id(select_pulse_rate).state);
+      on_raw_value:
+        then:
+          - light.turn_on:
+              id: led_red
+              flash_length: 100ms
 
   # Total day usage
   - platform: total_daily_energy


### PR DESCRIPTION
In #135 it was determined that when the Pulse Meter reads the same duration between subsequent pulses, the sensor is not updated and `on_raw_value` is never triggered so the LED never flashes.  This becomes increasingly likely during high usage as pulse durations become shorter.
This PR moves the trigger to the Pulse Meter's Total sensor, which does get triggered for every pulse.
The `light.turn_on` action can also be called with a `flash_length` parameter, rather than using `turn_on`, `delay`, `turn_off`.  

During high pulse rates a first pulse's `turn_off` may trigger between a later pulse's `turn_on` and `turn_off`, resulting in inconsistent flash lengths, though I'm not sure if using `flash_length` might address this.  With a meter that pulses for each Wh (1000 / kWh), 100ms flashes should be distinct for loads below 36 kW, while 200ms flashes would overlap at 18kW.