### PR TITLE
Rename ESPHome dashboard to compiler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ First, fill your 🛒 or see if you already have the components below.
 Choose one of the listed microcontrollers, but keep in mind that the ESP32 is recommended.
 
   - ESP32 (recommended) - [AliExpress](https://s.click.aliexpress.com/e/_DdAe4Fl) or [Banggood][esp32-bg-shop] or [AliExpress][esp32-ali-shop]
-  - ESP8266 - [AliExpress](https://s.click.aliexpress.com/e/_DCd13n1) or [Banggood][esp8266-bg-shop] or [AliExpress][esp8266-ali-shop]
+  - ESP8266 - [AliExpress](https://s.click.aliexpress.com/e/_omR3PTr) or [Banggood][esp8266-bg-shop] or [AliExpress][esp8266-ali-shop]
 - Dupont Jumpers (female to female) - [AliExpress](https://s.click.aliexpress.com/e/_DmbrJsj) or [Banggood][dupont-jumpers-shop]
 - 3D-printed case (see the [case](https://glow-energy.io/docs/reference/cases) folder)
 - LM393 Photodiode: [AliExpress](https://s.click.aliexpress.com/e/_DDkX3zN) or [Banggood][photodiode-bg-shop] or [AliExpress][photodiode-ali-shop] (please note that you will not receive an LDR)

--- a/docs/blog/2024-01-11-fresh-new-start.md
+++ b/docs/blog/2024-01-11-fresh-new-start.md
@@ -25,7 +25,7 @@ TL;DR - A lot 😅 ... v4.0.0 has been released, the most important changes are 
 1. The pulse meter pin for ESP32 boards has been changed from GPIO `13` to GPIO `26`.
 2. The `home_assistant_glow.yaml` file no longer exists.
 
-This would break the **package_import** for existing configs for people in the ESPHome dashboard. If you would like to use the latest version, I recommend re-flashing your ESP according to step 2 in [Getting Started](/docs/getting-started#step-2-install-firmware), and if desired, [re-adopting](/docs/advanced/firmware_changes#adopting-the-device) your device again in ESPHome dashboard (add-on).
+This would break the **package_import** for existing configs for people in the ESPHome Compiler (add-on). If you would like to use the latest version, I recommend re-flashing your ESP according to step 2 in [Getting Started](/docs/getting-started#step-2-install-firmware), and if desired, [re-adopting](/docs/advanced/firmware_changes#adopting-the-device) your device again in ESPHome compiler (add-on).
 
 ### New config structure
 

--- a/docs/docs/advanced/firmware_changes.mdx
+++ b/docs/docs/advanced/firmware_changes.mdx
@@ -8,11 +8,11 @@ description: Learn how to customize the firmware of the Glow using ESPHome.
 
 The Glow's firmware is built on [ESPHome](https://esphome.io), a platform designed for customization through simple YAML configurations. Whether you need to tweak the device's functionality or adapt it for different use cases, the process is straightforward.
 
-This guide will walk you through how to adopt the device and customize its firmware using the [ESPHome Dashboard](https://esphome.io/guides/getting_started_hassio.html).
+This guide will walk you through how to adopt the device and customize its firmware using the [ESPHome Compiler](https://esphome.io/guides/getting_started_hassio.html).
 
 ## Adopting the Device
 
-Before making any changes to the firmware, you first need to adopt the device into the ESPHome. Once your ESPHome Dashboard is up and running, and the Glow is connected to your local network, you should see an option to adopt it.
+Before making any changes to the firmware, you first need to adopt the device into the ESPHome. Once your ESPHome Compiler is up and running, and the Glow is connected to your local network, you should see an option to adopt it.
 
 <p align="left">
   <img src={require('@site/static/img/customization/adopt-esphome.png').default} />
@@ -38,7 +38,7 @@ The firmware is designed to be flexible for different ESP boards by breaking it 
 
 ### Making Your First Customization
 
-Once your device is adopted, you can start customizing its behavior by editing the configuration files. In the ESPHome dashboard, click on **EDIT** next to the device to open the YAML editor, where you can modify the configuration directly.
+Once your device is adopted, you can start customizing its behavior by editing the configuration files. In the ESPHome Compiler, click on **EDIT** next to the device to open the YAML editor, where you can modify the configuration directly.
 
 <p align="left">
   <img src={require('@site/static/img/customization/edit-device.png').default} />

--- a/docs/docs/advanced/firmware_updates.mdx
+++ b/docs/docs/advanced/firmware_updates.mdx
@@ -28,7 +28,7 @@ The easiest way to update the firmware of the Glow is through Home Assistant. Wh
 </p>
 
 :::note
-Since ESPHome 2024.6.x, the update component can directly retrieve firmware updates from the glow energy manifest. Which has made updating even easier and eliminates the need to use ESPHome Dashboard add-on just for updates.
+Since ESPHome 2024.6.x, the update component can directly retrieve firmware updates from the [glow-energy.io](https://glow-energy.io) manifest. Which has made updating even easier and eliminates the need to use ESPHome Compiler (add-on) just for updates.
 :::
 
 ## Glow Web Interface
@@ -47,13 +47,13 @@ If you are unable to update the firmware through Home Assistant, you can also up
 
 After the update is complete, the device will automatically reboot with the new firmware.
 
-## ESPHome Dashboard
+## ESPHome Compiler
 
 _Level of Difficulty: **Advanced**_
 
-If you are using the ESPHome Dashboard add-on in Home Assistant, you can also update the firmware through the dashboard. This method is useful if you have adopted the firmware to your ESPHome dashboard and know how to tweak the YAML configuration.
+If you are using the ESPHome Compiler add-on in Home Assistant, you can also update the firmware through the compiler dashboard. This method is useful if you have adopted the firmware to your ESPHome Compiler and know how to tweak the YAML configuration.
 
-1. Open the ESPHome Dashboard.
+1. Open the ESPHome Compiler (add-on).
 2. If it is possible to update the firmware, you will see an update button at the device card (see image below).
 3. Click on the **UPDATE** button to start the process.
 4. Select **Wirelessly** to update the firmware over-the-air (OTA).
@@ -65,6 +65,6 @@ Once the update is complete, the device will automatically reboot with the new f
   <img 
     width="80%"
     src={require('@site/static/img/advanced/glow_update-esphome.png').default}
-    alt="Update firmware through ESPHome Dashboard"
+    alt="Update firmware through ESPHome Compiler (add-on)"
   />
 </p>

--- a/docs/docs/faq/faq_nr8.md
+++ b/docs/docs/faq/faq_nr8.md
@@ -4,7 +4,7 @@ title: How to set OTA password
 description: How to set an OTA password for your ESPHome device
 ---
 
-Since [release v4.1.0](/blog/release-4.1.0#esphome-ota-updates), the OTA component is in a separate (external) [package], so it is no longer in your config when you adopt the Home Assistant Glow in ESPHome dashboard. Fortunately, the ESPHome platform has an ID under the OTA component so you can use [!extend]. This way, you can set the OTA password in your Glow configuration.
+Since [release v4.1.0](/blog/release-4.1.0#esphome-ota-updates), the OTA component is in a separate (external) [package], so it is no longer in your config when you adopt the Home Assistant Glow in ESPHome Compiler (add-on). Fortunately, the ESPHome platform has an ID under the OTA component so you can use [!extend]. This way, you can set the OTA password in your Glow configuration.
 
 ```yaml title="your_glow_config.yaml"
 ota:

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -20,7 +20,7 @@ To get started, you need the right hardware first, fill your 🛒 or see if you 
 | Nr.  | Item     | Shops |  |  |
 |:-----|:---------|:------|:-|:-|
 |**1.**| ESP32 (recommended) | [AliExpress](https://s.click.aliexpress.com/e/_DdAe4Fl) | [AliExpress][esp32-ali-shop] | [Banggood][esp32-bg-shop] |
-|**1.**| ESP8266  | [AliExpress](https://s.click.aliexpress.com/e/_DCd13n1) | [AliExpress][esp8266-ali-shop] | [Banggood][esp8266-bg-shop] |
+|**1.**| ESP8266  | [AliExpress](https://s.click.aliexpress.com/e/_omR3PTr) | [AliExpress][esp8266-ali-shop] | [Banggood][esp8266-bg-shop] |
 |**2.**| Dupont Jumpers (female to female) | [AliExpress](https://s.click.aliexpress.com/e/_DmbrJsj) | [AliExpress][dupont-jumpers-ali-shop] | [Banggood][dupont-jumpers-bg-shop] |
 |**3.**| LM393 Photodiode | [AliExpress](https://s.click.aliexpress.com/e/_DDkX3zN) | [AliExpress][photodiode-ali-shop] | [Banggood][photodiode-bg-shop] |
 |**4.**| LED RGB 5mm 4 pin - kathode | [AliExpress](https://s.click.aliexpress.com/e/_Dn1D0wT) | [AliExpress][rgbled-ali-shop] | [Banggood][rgbled-bg-shop] |
@@ -142,13 +142,14 @@ Congratulations 🎉 You have gone successfully through everything to get starte
 Affiliate links are used on this website to support the Home Assistant Glow 🌟 project. Some Ad-blockers might block these links, and thus they seem to appear broken. You will have to temporarily disable ad-blocker to open these links.
 
 {/* Hardware */}
-[esp32-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=https%3A%2F%2Fnl.banggood.com%2FGeekcreit-ESP32-WiFi%2Bbluetooth-Development-Board-Ultra-Low-Power-Consumption-Dual-Cores-Pins-Unsoldered-p-1214159.html
 [esp32-ali-shop]: https://tc.tradetracker.net/?c=15640&m=12&a=417111&r=&u=https%3A%2F%2Faliexpress.com%2Fitem%2F1005005970816555.html
-[esp8266-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=%2Fnl%2FGeekcreit-NodeMcu-Lua-ESP8266-ESP-12F-WIFI-Development-Board-p-985891.html
 [esp8266-ali-shop]: https://tc.tradetracker.net/?c=15640&m=12&a=417111&r=&u=https%3A%2F%2Faliexpress.com%2Fitem%2F1005005977505151.html
-[dupont-jumpers-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=https%3A%2F%2Fnl.banggood.com%2F120pcs-20cm-Male-To-Female-Female-To-Female-Male-To-Male-Color-Breadboard-Jumper-Cable-Dupont-Wire-p-974006.html
 [dupont-jumpers-ali-shop]: https://tc.tradetracker.net/?c=15640&m=12&a=417111&r=&u=https%3A%2F%2Faliexpress.com%2Fitem%2F1005005945668553.html
-[photodiode-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=https%3A%2F%2Fnl.banggood.com%2F4Pin-Photodiode-Sensor-Controller-Module-Measure-Module-p-1416445.html
 [photodiode-ali-shop]: https://tc.tradetracker.net/?c=15640&m=12&a=417111&r=&u=https%3A%2F%2Faliexpress.com%2Fitem%2F1005003302215339.html
-[rgbled-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=https%3A%2F%2Fnl.banggood.com%2F50pcs-LED-RGB-Common-Cathode-4-Pin-F5-5MM-Diode-p-1016398.html
 [rgbled-ali-shop]: https://tc.tradetracker.net/?c=15640&m=12&a=417111&r=&u=%2Fitem%2F4000225253691.html
+
+[esp32-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=https%3A%2F%2Fnl.banggood.com%2FGeekcreit-ESP32-WiFi%2Bbluetooth-Development-Board-Ultra-Low-Power-Consumption-Dual-Cores-Pins-Unsoldered-p-1214159.html
+[esp8266-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=%2Fnl%2FGeekcreit-NodeMcu-Lua-ESP8266-ESP-12F-WIFI-Development-Board-p-985891.html
+[dupont-jumpers-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=https%3A%2F%2Fnl.banggood.com%2F120pcs-20cm-Male-To-Female-Female-To-Female-Male-To-Male-Color-Breadboard-Jumper-Cable-Dupont-Wire-p-974006.html
+[photodiode-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=https%3A%2F%2Fnl.banggood.com%2F4Pin-Photodiode-Sensor-Controller-Module-Measure-Module-p-1416445.html
+[rgbled-bg-shop]: https://www.banggood.com/bang/?tt=16956_12_417111_&r=https%3A%2F%2Fnl.banggood.com%2F50pcs-LED-RGB-Common-Cathode-4-Pin-F5-5MM-Diode-p-1016398.html


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Documentation**
  - Updated terminology from "ESPHome Dashboard" to "ESPHome Compiler" across multiple documentation files
  - Updated AliExpress link for ESP8266 microcontroller
  - Added shopping links for ESP32, Dupont Jumpers, LM393 Photodiode, and RGB LED in getting started guide
  - Minor formatting and link consistency improvements

- **Chores**
  - Refined documentation language and references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->