### PR TITLE
Minor typo in 'select_pulse_rate' number

### DIFF
--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -12,7 +12,7 @@ number:
   # Set the pulse rate of the LED on your meter
   - platform: template
     id: select_pulse_rate
-    name: 'Puls rate - imp/kWh'
+    name: 'Pulse rate - imp/kWh'
     optimistic: true
     mode: box
     min_value: 100


### PR DESCRIPTION
Type in name for  'select_pulse_rate' number. - 'Puls rate' instead of 'Pulse rate'

This may effect how this sensor is used/displayed in Home Assistant for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the pulse rate display label to ensure consistent and clear wording.
  
- **Style**
	- Made a minor formatting adjustment for improved file termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->