### PR TITLE
fix: Update repository URL for PRs from forks in build firmware workflow

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -49,7 +49,7 @@ jobs:
           # For PRs from forks, also update the repository URL
           if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ] && [ -n "${{ github.event.pull_request.head.repo.full_name }}" ]; then
             echo "Updating repository URL for fork: ${{ github.event.pull_request.head.repo.full_name }}"
-            sed -i "s|url: https://github.com/${{ github.repository }}/|url: https://github.com/${{ github.event.pull_request.head.repo.full_name }}/|g" home-assistant-glow/${{ matrix.device }}.yaml
+            sed -i "s|^\([[:space:]]*\)url: https://github.com/${{ github.repository }}/|\1url: https://github.com/${{ github.event.pull_request.head.repo.full_name }}/|g" home-assistant-glow/${{ matrix.device }}.yaml
           fi
       - name: 🔨 Build firmware
         uses: esphome/build-action@v7.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build workflow now correctly handles pull requests from forked repositories by updating build configuration references to use the fork’s repository when applicable, ensuring builds for fork PRs use the forked configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->