### PR TITLE
fix: Update pulse rate label to use correct fraction format

### DIFF
--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -12,7 +12,7 @@ number:
   # Set the pulse rate of the LED on your meter
   - platform: template
     id: select_pulse_rate
-    name: 'Pulse rate - imp/kWh'
+    name: 'Pulse rate - imp⁄kWh'
     optimistic: true
     mode: box
     min_value: 10

--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -12,7 +12,8 @@ number:
   # Set the pulse rate of the LED on your meter
   - platform: template
     id: select_pulse_rate
-    name: 'Pulse rate - imp⁄kWh'
+    name: 'Pulse rate'
+    unit_of_measurement: imp/kWh
     optimistic: true
     mode: box
     min_value: 10

--- a/docs/docs/configuration/pulse_rate.mdx
+++ b/docs/docs/configuration/pulse_rate.mdx
@@ -14,7 +14,7 @@ You can adjust the value in 2 ways:
 
 ### Option 1: Via the web interface
 
-You open the web server by going to the IP address of your Home Assistant Glow, where you will find the line **Pulse rate - imp⁄kWh** in the table, and you can then adjust it on the right.
+You open the web server by going to the IP address of your Home Assistant Glow, where you will find the line **Pulse rate** in the table, and you can then adjust it on the right.
 
 <p align="left">
   <img 
@@ -27,7 +27,7 @@ You open the web server by going to the IP address of your Home Assistant Glow, 
 ### Option 2: In Home Assistant
 
 1. Go to the device overview page of the Home Assistant Glow, via [**Settings** > **Devices & Services** > **ESPHome**](https://my.home-assistant.io/redirect/integration/?domain=esphome).
-2. Adjust the value for the entity **Pulse rate - imp⁄kWh**.
+2. Adjust the value for the entity **Pulse rate**.
 
 ## Useful resources
 

--- a/docs/docs/configuration/pulse_rate.mdx
+++ b/docs/docs/configuration/pulse_rate.mdx
@@ -14,7 +14,7 @@ You can adjust the value in 2 ways:
 
 ### Option 1: Via the web interface
 
-You open the web server by going to the IP address of your Home Assistant Glow, where you will find the line **Pulse rate - imp/kWh** in the table, and you can then adjust it on the right.
+You open the web server by going to the IP address of your Home Assistant Glow, where you will find the line **Pulse rate - imp⁄kWh** in the table, and you can then adjust it on the right.
 
 <p align="left">
   <img 
@@ -27,7 +27,7 @@ You open the web server by going to the IP address of your Home Assistant Glow, 
 ### Option 2: In Home Assistant
 
 1. Go to the device overview page of the Home Assistant Glow, via [**Settings** > **Devices & Services** > **ESPHome**](https://my.home-assistant.io/redirect/integration/?domain=esphome).
-2. Adjust the value for the entity **Pulse rate - imp/kWh**.
+2. Adjust the value for the entity **Pulse rate - imp⁄kWh**.
 
 ## Useful resources
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -129,7 +129,7 @@ There are two ways to adjust the pulse rate:
 
 ### Option 1 - Via the web interface
 
-Access the web interface by navigating to the IP address of your Home Assistant Glow. Once there, you'll find a table with a row labeled **Pulse rate - imp/kWh**, where you can easily adjust the value in the column on the right.
+Access the web interface by navigating to the IP address of your Home Assistant Glow. Once there, you'll find a table with a row labeled **Pulse rate - imp⁄kWh**, where you can easily adjust the value in the column on the right.
 
 <p align="left">
   <img
@@ -146,7 +146,7 @@ Access the web interface by navigating to the IP address of your Home Assistant 
 ### Option 2 - In Home Assistant
 
 1. Go to the device overview page of the Home Assistant Glow, via [**Settings** > **Devices & Services** > **ESPHome**](https://my.home-assistant.io/redirect/integration/?domain=esphome).
-2. Adjust the value for the entity **Pulse rate - imp/kWh**.
+2. Adjust the value for the entity **Pulse rate - imp⁄kWh**.
 
 </div>
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -129,7 +129,7 @@ There are two ways to adjust the pulse rate:
 
 ### Option 1 - Via the web interface
 
-Access the web interface by navigating to the IP address of your Home Assistant Glow. Once there, you'll find a table with a row labeled **Pulse rate - imp⁄kWh**, where you can easily adjust the value in the column on the right.
+Access the web interface by navigating to the IP address of your Home Assistant Glow. Once there, you'll find a table with a row labeled **Pulse rate**, where you can easily adjust the value in the column on the right.
 
 <p align="left">
   <img
@@ -146,7 +146,7 @@ Access the web interface by navigating to the IP address of your Home Assistant 
 ### Option 2 - In Home Assistant
 
 1. Go to the device overview page of the Home Assistant Glow, via [**Settings** > **Devices & Services** > **ESPHome**](https://my.home-assistant.io/redirect/integration/?domain=esphome).
-2. Adjust the value for the entity **Pulse rate - imp⁄kWh**.
+2. Adjust the value for the entity **Pulse rate**.
 
 </div>
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This cleans up the pulse rate number entity by moving `imp/kWh` out of the entity name and exposing it as the unit of measurement instead.

### Changes

- Rename the pulse rate number entity from `Pulse rate - imp/kWh` to `Pulse rate`
- Add `imp/kWh` as the unit of measurement for the pulse rate number entity
- Update the documentation to reference the new shorter entity label

### Notes

Existing Home Assistant installations should generally keep their current entity registry entry, but new setups may generate a shorter entity ID for the pulse rate entity.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes: #963 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Dependency update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Tested on ESP32
- [X] Tested on ESP32-C3
- [X] Tested on ESP8266
- [X] Tested in Home Assistant

**Test Configuration**:
- ESPHome version:
- Hardware:
- Meter type:

## Checklist
<!-- Put an `x` in all the boxes that apply. -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have tested my changes and confirmed they work as expected