### PR TITLE
ci: Use build-action substitutions input for package source overrides

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -42,9 +42,36 @@ env:
   RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/latest
 
 jobs:
+  prepare:
+    name: Prepare build
+    runs-on: ubuntu-latest
+    outputs:
+      substitutions: ${{ steps.package-source.outputs.substitutions }}
+    steps:
+      - name: 🔍 Set ESPHome package source for dev/PR builds
+        id: package-source
+        if: ${{ !contains(fromJSON('["release", "workflow_call"]'), github.event_name) }}
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$PR_HEAD_REPO" != "$REPO" ] && [ -n "$PR_HEAD_REPO" ]; then
+            PACKAGE_URL="https://github.com/${PR_HEAD_REPO}/"
+          else
+            PACKAGE_URL="https://github.com/${REPO}/"
+          fi
+          {
+            echo "substitutions<<EOF"
+            echo "package_url=${PACKAGE_URL}"
+            echo "package_ref=${HEAD_REF}"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
   build:
     name: ${{ matrix.device }} / ${{ matrix.variant }}
     runs-on: ubuntu-latest
+    needs: prepare
     strategy:
       max-parallel: 5
       fail-fast: false
@@ -59,43 +86,25 @@ jobs:
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v6.0.2
-      - name: 🔧 Set build variables
-        id: vars
-        run: |
-          echo "suffix=${{ matrix.device }}" >> $GITHUB_OUTPUT
-          echo "yaml=${{ matrix.folder }}/${{ matrix.device }}.yaml" >> $GITHUB_OUTPUT
-      - name: 🔍 Update ESPHome package ref for dev/PR builds
-        if: ${{ !contains(fromJSON('["release", "workflow_call"]'), github.event_name) }}
-        env:
-          HEAD_REF: ${{ github.head_ref || github.ref_name }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          REPO: ${{ github.repository }}
-          YAML_FILE: ${{ steps.vars.outputs.yaml }}
-        run: |
-          sed -i "s|ref: .*|ref: \"${HEAD_REF}\"|g" "$YAML_FILE"
-          if [ "$PR_HEAD_REPO" != "$REPO" ] && [ -n "$PR_HEAD_REPO" ]; then
-            echo "Updating repository URL for fork: $PR_HEAD_REPO"
-            sed -i "s|^\([[:space:]]*\)url: https://github.com/${REPO}/|\1url: https://github.com/${PR_HEAD_REPO}/|g" "$YAML_FILE"
-          fi
       - name: 🔨 Build firmware
         uses: esphome/build-action@v7.3.0
         id: esphome-build
         with:
-          yaml-file: ${{ steps.vars.outputs.yaml }}
+          yaml-file: ${{ matrix.folder }}/${{ matrix.device }}.yaml
           version: latest
           release-summary: ${{ inputs.release-summary || 'Check the release notes for more information.' }}
           release-url: ${{ inputs.release-url || env.RELEASE_URL }}
+          substitutions: ${{ needs.prepare.outputs.substitutions }}
       - name: 🚚 Prepare output artifacts
         run: |
           set -e
-          SUFFIX="${{ steps.vars.outputs.suffix }}"
-          mkdir -p output/$SUFFIX
-          mv ${{ steps.esphome-build.outputs.name }}/* output/$SUFFIX/
-          echo "${{ steps.esphome-build.outputs.version }}" > output/$SUFFIX/version
-          echo "${{ steps.esphome-build.outputs.project-version }}" > output/$SUFFIX/project_version
-          sed -i "s|${{ steps.esphome-build.outputs.name }}\(\.[a-z]*\)\.bin|/${{ matrix.folder }}/$SUFFIX/${{ steps.esphome-build.outputs.name }}\1.bin|" output/$SUFFIX/manifest.json
-          jq --arg variant "${{ matrix.variant }}" '. + {variant: $variant}' output/$SUFFIX/manifest.json > output/$SUFFIX/manifest.json.tmp
-          mv output/$SUFFIX/manifest.json.tmp output/$SUFFIX/manifest.json
+          mkdir -p output/${{ matrix.device }}
+          mv ${{ steps.esphome-build.outputs.name }}/* output/${{ matrix.device }}/
+          echo "${{ steps.esphome-build.outputs.version }}" > output/${{ matrix.device }}/version
+          echo "${{ steps.esphome-build.outputs.project-version }}" > output/${{ matrix.device }}/project_version
+          sed -i "s|${{ steps.esphome-build.outputs.name }}\(\.[a-z]*\)\.bin|/${{ matrix.folder }}/${{ matrix.device }}/${{ steps.esphome-build.outputs.name }}\1.bin|" output/${{ matrix.device }}/manifest.json
+          jq --arg variant "${{ matrix.variant }}" '. + {variant: $variant}' output/${{ matrix.device }}/manifest.json > output/${{ matrix.device }}/manifest.json.tmp
+          mv output/${{ matrix.device }}/manifest.json.tmp output/${{ matrix.device }}/manifest.json
 
       - name: ⬆️ Upload firmware artifact
         uses: actions/upload-artifact@v7.0.1
@@ -108,7 +117,7 @@ jobs:
     name: Comment on PR
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    needs: build
+    needs: [prepare, build]
     permissions:
       pull-requests: write
     steps:

--- a/glow-basic/esp32.yaml
+++ b/glow-basic/esp32.yaml
@@ -11,6 +11,8 @@ substitutions:
   project_version: "4.4.0"
   device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP32 Generic (basic)"
   update_manifest_url: "https://glow-energy.io/glow-basic/manifest.json"
+  package_url: "https://github.com/klaasnicolaas/home-assistant-glow/"
+  package_ref: "${project_version}"
 
   # Define the GPIO pins
   pulse_pin: GPIO26
@@ -34,8 +36,8 @@ esp32:
 
 packages:
   remote_package:
-    url: https://github.com/klaasnicolaas/home-assistant-glow/
-    ref: "4.4.0"
+    url: "${package_url}"
+    ref: "${package_ref}"
     files:
       - components/basis.yaml
       - components/updates.yaml

--- a/glow-basic/esp32c3.yaml
+++ b/glow-basic/esp32c3.yaml
@@ -11,6 +11,8 @@ substitutions:
   project_version: "4.4.0"
   device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP32-C3 (basic)"
   update_manifest_url: "https://glow-energy.io/glow-basic/manifest.json"
+  package_url: "https://github.com/klaasnicolaas/home-assistant-glow/"
+  package_ref: "${project_version}"
 
   # Define the GPIO pins
   pulse_pin: GPIO10
@@ -34,8 +36,8 @@ esp32:
 
 packages:
   remote_package:
-    url: https://github.com/klaasnicolaas/home-assistant-glow/
-    ref: "4.4.0"
+    url: "${package_url}"
+    ref: "${package_ref}"
     files:
       - components/basis.yaml
       - components/updates.yaml

--- a/glow-basic/esp8266.yaml
+++ b/glow-basic/esp8266.yaml
@@ -11,6 +11,8 @@ substitutions:
   project_version: "4.4.0"
   device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP8266 Generic (basic)"
   update_manifest_url: "https://glow-energy.io/glow-basic/manifest.json"
+  package_url: "https://github.com/klaasnicolaas/home-assistant-glow/"
+  package_ref: "${project_version}"
 
   # Define the GPIO pins
   pulse_pin: GPIO13
@@ -32,8 +34,8 @@ esp8266:
 
 packages:
   remote_package:
-    url: https://github.com/klaasnicolaas/home-assistant-glow/
-    ref: "4.4.0"
+    url: "${package_url}"
+    ref: "${package_ref}"
     files:
       - components/basis.yaml
       - components/updates.yaml

--- a/home-assistant-glow/esp32.yaml
+++ b/home-assistant-glow/esp32.yaml
@@ -11,6 +11,8 @@ substitutions:
   project_version: "4.4.0"
   device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP32 Generic"
   update_manifest_url: "https://glow-energy.io/home-assistant-glow/manifest.json"
+  package_url: "https://github.com/klaasnicolaas/home-assistant-glow/"
+  package_ref: "${project_version}"
 
   # Define the GPIO pins
   pulse_pin: GPIO26
@@ -37,8 +39,8 @@ esp32:
 
 packages:
   remote_package:
-    url: https://github.com/klaasnicolaas/home-assistant-glow/
-    ref: "4.4.0"
+    url: "${package_url}"
+    ref: "${package_ref}"
     files:
       - components/basis.yaml
       - components/updates.yaml

--- a/home-assistant-glow/esp32c3.yaml
+++ b/home-assistant-glow/esp32c3.yaml
@@ -11,6 +11,8 @@ substitutions:
   project_version: "4.4.0"
   device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP32-C3"
   update_manifest_url: "https://glow-energy.io/home-assistant-glow/manifest.json"
+  package_url: "https://github.com/klaasnicolaas/home-assistant-glow/"
+  package_ref: "${project_version}"
 
   # Define the GPIO pins
   pulse_pin: GPIO10
@@ -37,8 +39,8 @@ esp32:
 
 packages:
   remote_package:
-    url: https://github.com/klaasnicolaas/home-assistant-glow/
-    ref: "4.4.0"
+    url: "${package_url}"
+    ref: "${package_ref}"
     files:
       - components/basis.yaml
       - components/updates.yaml

--- a/home-assistant-glow/esp8266.yaml
+++ b/home-assistant-glow/esp8266.yaml
@@ -11,6 +11,8 @@ substitutions:
   project_version: "4.4.0"
   device_description: "Measure your energy consumption with the pulse LED on your smart meter - ESP8266 Generic"
   update_manifest_url: "https://glow-energy.io/home-assistant-glow/manifest.json"
+  package_url: "https://github.com/klaasnicolaas/home-assistant-glow/"
+  package_ref: "${project_version}"
 
   # Define the GPIO pins
   pulse_pin: GPIO13
@@ -35,8 +37,8 @@ esp8266:
 
 packages:
   remote_package:
-    url: https://github.com/klaasnicolaas/home-assistant-glow/
-    ref: "4.4.0"
+    url: "${package_url}"
+    ref: "${package_ref}"
     files:
       - components/basis.yaml
       - components/updates.yaml


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Upgrades the build workflow to use `esphome/build-action@v7.3.0`, which introduces native `substitutions` support. This replaces the previous `sed`-based approach of directly mutating YAML files before building.

- **`prepare` job** – runs once before the matrix and computes `package_url` / `package_ref` for dev and fork builds, exposing them as a single `substitutions` output. Release builds skip this step and let the YAML defaults apply.
- **`build` jobs** – receive the substitutions via `needs.prepare.outputs.substitutions`; the redundant `vars` step is removed and matrix expressions are used directly.
- **Device YAMLs** – `package_ref` is now `${project_version}` instead of a hardcoded version string, so bumping `project_version` is the only change needed on release.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Configuration change
- [ ] Dependency update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Tested on ESP32
- [ ] Tested on ESP32-C3
- [ ] Tested on ESP8266
- [ ] Tested in Home Assistant

**Test Configuration**:
- ESPHome version:
- Hardware:
- Meter type:

## Checklist
<!-- Put an `x` in all the boxes that apply. -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes and confirmed they work as expected