### PR TITLE
Change unit_of_measurement format ito match ESPHome 2026.7.0

### DIFF
--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -13,7 +13,7 @@ number:
   - platform: template
     id: select_pulse_rate
     name: 'Pulse rate'
-    unit_of_measurement: imp/kWh
+    unit_of_measurement: imp per kWh
     optimistic: true
     mode: box
     min_value: 10


### PR DESCRIPTION
## Description
This Pr is to change the `unit_of_measurement` to match the new version of ESPHome. `/` will only be used  for URLs

## Motivation and Context
```WARNING 'Pulse rate - imp/kWh' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Pulse rate - imp⁄kWh' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.```

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration change
- [ ] Dependency update

## How Has This Been Tested?
I have override this locally in my ESPHome yaml

- [x] Tested on ESP32-C6
- [ ] Tested on ESP32-C3
- [ ] Tested on ESP8266
- [x] Tested in Home Assistant

**Test Configuration**:
- ESPHome version:  2026.5.2 
- Hardware: ESP32-c6 dev board
- Meter type:

## Checklist
<!-- Put an `x` in all the boxes that apply. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes and confirmed they work as expected