### PR TITLE
Add configurable pulse meter internal filter

### DIFF
--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -22,6 +22,22 @@ number:
     restore_value: yes
     initial_value: 1000
 
+  # Set the internal filter of the pulse meter (in microseconds)
+  - platform: template
+    id: select_internal_filter
+    name: 'Internal Filter'
+    entity_category: config
+    unit_of_measurement: µs
+    optimistic: true
+    mode: box
+    min_value: 13
+    max_value: 30000
+    step: 1
+    restore_value: yes
+    initial_value: 1000
+    on_value:
+      - lambda: id(sensor_energy_pulse_meter).set_filter_us((uint32_t)x);
+
   # Reset total energy to given value
   - platform: template
     id: select_reset_total

--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -31,7 +31,7 @@ number:
     optimistic: true
     mode: box
     min_value: 13
-    max_value: 30000
+    max_value: 100000
     step: 1
     restore_value: yes
     initial_value: 1000

--- a/docs/docs/advanced/firmware_changes.mdx
+++ b/docs/docs/advanced/firmware_changes.mdx
@@ -63,13 +63,17 @@ You can find all component IDs by viewing the [component YAML files](https://git
 
 When you open the YAML editor, you'll see the default configuration for your Glow device. You can adjust this configuration or add new functionality by extending the existing components. For example, to change the behavior of the [pulse_meter], you can use the [!extend] feature to easily make the necessary changes.
 
-Here's an example of adding an [internal_filter] to the pulse meter configuration:
+Here's an example of increasing the accuracy of the total energy sensor to 5 decimal places:
 
 ```yaml title="your_glow_config.yaml"
 sensor:
-  - id: !extend sensor_energy_pulse_meter
-    internal_filter: 100ms
+  - id: !extend sensor_total_energy
+    accuracy_decimals: 5
 ```
+
+:::note
+Some settings, like the **internal filter**, are no longer configurable via YAML and must be adjusted through the Home Assistant UI or the built-in web interface. See the [Internal Filter](/docs/configuration/internal_filter) page for more information.
+:::
 
 ## Reverting to Default Firmware
 
@@ -91,7 +95,6 @@ Before reverting, consider backing up your custom YAML configuration in case you
 - [ESPHome - OTA Updates][ota]
 - [ESPHome - Remote Packages][remote]
 
-[internal_filter]: https://esphome.io/components/sensor/pulse_counter.html?highlight=internal_filter
 [pulse_meter]: https://esphome.io/components/sensor/pulse_counter.html
 [!extend]: https://esphome.io/components/packages.html#extend
 [ota]: https://esphome.io/components/ota/

--- a/docs/docs/advanced/firmware_changes.mdx
+++ b/docs/docs/advanced/firmware_changes.mdx
@@ -90,12 +90,12 @@ Before reverting, consider backing up your custom YAML configuration in case you
 
 ## Helpful Resources
 
-- [ESPHome - Pulse Counter][pulse_meter]
+- [ESPHome - Pulse Meter][pulse_meter]
 - [ESPHome - Extend][!extend]
 - [ESPHome - OTA Updates][ota]
 - [ESPHome - Remote Packages][remote]
 
-[pulse_meter]: https://esphome.io/components/sensor/pulse_counter.html
+[pulse_meter]: https://esphome.io/components/sensor/pulse_meter.html
 [!extend]: https://esphome.io/components/packages.html#extend
 [ota]: https://esphome.io/components/ota/
 [remote]: https://esphome.io/components/packages.html#remote-git-packages

--- a/docs/docs/configuration/internal_filter.mdx
+++ b/docs/docs/configuration/internal_filter.mdx
@@ -1,0 +1,37 @@
+---
+id: internal_filter
+title: Internal Filter
+description: Learn how to adjust the internal filter of your Home Assistant Glow device to reduce ghost detections.
+---
+
+# Adjust the Internal Filter
+
+The Glow uses a pulse meter to track energy usage. In some situations, electrical noise or reflections near the meter's LED can cause false pulse detections, also known as **ghost pulses**. These show up as unrealistic power spikes (e.g. 1000 kW) in Home Assistant.
+
+The internal filter defines the minimum duration (in microseconds) a signal must be active before it is counted as a valid pulse. Increasing this value filters out short noise pulses, reducing ghost detections.
+
+The Glow defaults to `1000` **µs** (1 ms). If you are experiencing ghost detections, try increasing this value gradually.
+
+:::caution
+Setting the internal filter too high can cause real pulses to be missed, especially at high power consumption or with meters that have a high imp/kWh rate. A value up to **10000 µs** (10 ms) is a good starting point for most residential setups.
+:::
+
+You can adjust the value in 2 ways:
+
+### Option 1: Via the web interface
+
+Open the web server by going to the IP address of your Home Assistant Glow, where you will find the line **Internal Filter** in the table, and you can adjust it on the right.
+
+### Option 2: In Home Assistant
+
+1. Go to the device overview page of the Home Assistant Glow, via [**Settings** > **Devices & Services** > **ESPHome**](https://my.home-assistant.io/redirect/integration/?domain=esphome).
+2. Adjust the value for the entity **Internal Filter** under the configuration section.
+
+:::note
+Since the internal filter is now controlled at runtime via the **Internal Filter** entity, overriding `internal_filter` directly on the pulse meter sensor in your YAML configuration will no longer work. The entity value always takes precedence after boot. Use one of the two options above instead.
+:::
+
+## Useful resources
+
+- [Glow Energy - FAQ page](/docs/faq)
+- [ESPHome Pulse Meter documentation](https://esphome.io/components/sensor/pulse_meter.html)

--- a/docs/docs/faq/faq_nr10.md
+++ b/docs/docs/faq/faq_nr10.md
@@ -1,0 +1,24 @@
+---
+id: ghost_pulses
+title: Unrealistic power spikes (ghost pulses)
+description: What to do when you see unrealistic power spikes caused by ghost pulse detections
+---
+
+Linked issue: [#983][issue_983]
+
+If you see sudden unrealistic power spikes (e.g. 1000 kW) in Home Assistant, this is likely caused by **ghost pulses**, which are false detections triggered by electrical noise or reflections near your meter's LED.
+
+## What to do?
+
+Increase the **Internal Filter** value on your device. This tells the pulse meter to ignore signals shorter than the configured duration, filtering out the noise that causes ghost detections.
+
+You can adjust this in Home Assistant via the device configuration page, or via the built-in web interface. See the [Internal Filter](/docs/configuration/internal_filter) configuration page for step-by-step instructions.
+
+A value between **1000 µs** (1 ms) and **10000 µs** (10 ms) is a good starting point for most setups.
+
+## Related topics
+
+- [Adjusting the Internal Filter](/docs/configuration/internal_filter)
+- [Customizing the Firmware](/docs/advanced/firmware_changes)
+
+[issue_983]: https://github.com/klaasnicolaas/home-assistant-glow/issues/983

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5042,9 +5042,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5060,9 +5057,6 @@
       "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5080,9 +5074,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5098,9 +5089,6 @@
       "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -21,6 +21,7 @@ const sidebars: SidebarsConfig = {
       label: 'Configuration',
       items: [
         'configuration/pulse_rate',
+        'configuration/internal_filter',
         'configuration/rename',
         'configuration/energy_dashboard',
       ],


### PR DESCRIPTION
## Description

Adds a configurable internal filter for the ESPHome `pulse_meter` used by Glow.

The internal filter can now be adjusted from Home Assistant and the device web UI, similar to the existing pulse rate setting. This makes it easier to tune pulse detection behavior without manually editing custom ESPHome YAML.

This PR also adds documentation explaining what the internal filter does, when users may want to adjust it, and how to choose a suitable value.

## Motivation and Context

Some users experience ghost pulse detections that can cause unrealistic power spikes. Issue #983 asks for a way to make the internal filter adjustable through the UI so users can tune filtering while still using the standard Glow firmware and updates.

This change makes that possible by exposing the internal filter as a configurable setting and documenting how to use it.

Fixes #983

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Configuration change
- [ ] Dependency update

## How Has This Been Tested?

- [x] Tested on ESP32
- [ ] Tested on ESP32-C3
- [ ] Tested on ESP8266
- [ ] Tested in Home Assistant

**Test Configuration**:
- ESPHome version:
- Hardware:
- Meter type:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes and confirmed they work as expected