### PR TITLE
refactor: Simplify sensor names in basis and pulse_meter configurations

### DIFF
--- a/components/basis.yaml
+++ b/components/basis.yaml
@@ -2,13 +2,13 @@
 button:
   # Restart the ESP
   - platform: restart
-    name: "Restart - Glow"
+    name: 'Restart'
 
 # Sensors for ESP version and WIFI information
 text_sensor:
   # Installed version
   - platform: template
-    name: "Glow - Installed version"
+    name: 'Installed Version'
     id: glow_version
     icon: "mdi:label-outline"
     entity_category: diagnostic
@@ -18,20 +18,20 @@ text_sensor:
   # ESPHome version
   - platform: version
     hide_timestamp: true
-    name: '${friendly_name} - ESPHome Version'
+    name: 'ESPHome Version'
   # IP address and connected SSID
   - platform: wifi_info
     ip_address:
-      name: '${friendly_name} - IP Address'
+      name: 'IP Address'
       icon: mdi:wifi
     ssid:
-      name: '${friendly_name} - Connected SSID'
+      name: 'Connected SSID'
       icon: mdi:wifi-strength-2
 
 sensor:
   # WiFi signal
   - platform: wifi_signal
-    name: "${friendly_name} - WiFi Signal"
+    name: 'WiFi Signal'
     update_interval: 120s
 
 # Enable time component to reset energy at midnight

--- a/components/pulse_meter.yaml
+++ b/components/pulse_meter.yaml
@@ -64,7 +64,7 @@ sensor:
   # Pulse meter
   - platform: pulse_meter
     id: sensor_energy_pulse_meter
-    name: '${friendly_name} - Power Consumption'
+    name: 'Power Consumption'
     unit_of_measurement: W
     state_class: measurement
     device_class: power
@@ -78,7 +78,7 @@ sensor:
 
     total:
       id: sensor_total_energy
-      name: '${friendly_name} - Total Energy'
+      name: 'Total Energy'
       unit_of_measurement: kWh
       icon: mdi:circle-slice-3
       state_class: total_increasing
@@ -95,7 +95,7 @@ sensor:
   # Total day usage
   - platform: total_daily_energy
     id: sensor_total_daily_energy
-    name: '${friendly_name} - Daily Energy'
+    name: 'Daily Energy'
     power_id: sensor_energy_pulse_meter
     unit_of_measurement: kWh
     icon: mdi:circle-slice-3


### PR DESCRIPTION
## Description

Updates the default Glow entity names to follow the modern ESPHome naming convention by removing the duplicated device name prefix.

The affected entities now use cleaner names such as `Power Consumption`, `Total Energy`, `Daily Energy`, `ESPHome Version`, `IP Address`, `Connected SSID`, `WiFi Signal`, `Installed Version`, and `Restart`.

## Motivation and Context

ESPHome now recommends using entity names without repeating the device name, since Home Assistant already shows entities in the context of their device. This keeps the Glow device page cleaner and avoids redundant entity names like `{device} - Power Consumption`.

This is a breaking change for existing installations because Home Assistant may create new entity IDs after updating. Users may need to update dashboards, automations, and Energy dashboard settings that reference the old entity IDs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration change
- [ ] Dependency update

## How Has This Been Tested?

- [ ] Tested on ESP32
- [ ] Tested on ESP32-C3
- [ ] Tested on ESP8266
- [ ] Tested in Home Assistant

**Test Configuration**:
- ESPHome version:
- Hardware:
- Meter type:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes and confirmed they work as expected