### PR TITLE
Use account funding defaults

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
----
-github: klaasnicolaas
-ko_fi: klaasnicolaas


### PR DESCRIPTION
Remove the funding file, which matches the new klaasnicolaas/.github default. Glow's hardware-specific issue forms, Discussions/docs links and PR testing checklist remain local overrides.

Merge the central community-default PR and legacy sync exclusions first. The funding content was compared before deletion; no firmware or runtime behavior changes. Check sponsor links after merge.

Dependencies: [central defaults](https://github.com/klaasnicolaas/.github/pull/4) and [legacy sync exclusions](https://github.com/klaasnicolaas/github-config/pull/444).
